### PR TITLE
fix: add missing comma to project dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "numpy",
   "pyarrow",
   "logfire",
-  "logfire[sqlalchemy]"
+  "logfire[sqlalchemy]",
   "ipython",
   "adlfs"
 ]


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change corrects a minor formatting issue by adding a comma after the `logfire[sqlalchemy]` dependency. 

Changes in `dependencies = [` in file `pyproject.toml`:

* Added a comma after `logfire[sqlalchemy]` to correct the formatting.