### PR TITLE
fix: fix logfire configuration indentation

### DIFF
--- a/src/flowbyte/telemetry.py
+++ b/src/flowbyte/telemetry.py
@@ -22,6 +22,13 @@ class Telemetry(BaseModel):
             code_source = None
             logfire_token = os.getenv("LOGFIRE_TOKEN")
 
+            if logfire_token is None:
+                _log.message = "FLOWBYTE | Telemetry: You can add your logfire token in .env using LOGFIRE_TOKEN"
+                _log.status = "warning"
+                _log.print_message()
+            else:
+                logfire.configure(token=logfire_token, environment="flowbyte", service_name="mssql", code_source=code_source)
+
         if self.include_syetem_metrics:
             logfire.instrument_system_metrics({
                 'process.runtime.cpu.utilization': ['used'],  
@@ -50,7 +57,7 @@ class Telemetry(BaseModel):
                 
             
 
-            logfire.configure(token=logfire_token, environment="flowbyte", service_name="mssql", code_source=code_source)
+            
 
 
 


### PR DESCRIPTION
This pull request includes changes to the `src/flowbyte/telemetry.py` file to improve the handling of the `LOGFIRE_TOKEN` environment variable. The most important changes include adding a warning message when the `LOGFIRE_TOKEN` is not set and ensuring that the `logfire.configure` method is only called when the token is available.

Improvements to environment variable handling:

* Added a warning message to notify users to add their `LOGFIRE_TOKEN` in the `.env` file if it is not set.
* Ensured that the `logfire.configure` method is only called when the `LOGFIRE_TOKEN` is available. [[1]](diffhunk://#diff-bc1f9e2240c843f851b74d42f162b0e3a08efbf2a6ee7195c99e511d3705c838R25-R31) [[2]](diffhunk://#diff-bc1f9e2240c843f851b74d42f162b0e3a08efbf2a6ee7195c99e511d3705c838L53-R60)